### PR TITLE
Allow importing user's real name

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,17 @@ $wgOAuth2Client['configuration']['username'] = 'username'; // JSON path to usern
 $wgOAuth2Client['configuration']['email'] = 'email'; // JSON path to email
 ```
 
+The user's real name will be set to the username by default.
+Depending on what you get from your backend, you may also want to configure:
+```
+$wgOAuth2Client['configuration']['real_name'] = 'realname'; // JSON path to real name
+```
+or:
+```
+$wgOAuth2Client['configuration']['first_name'] = 'first_name'; // JSON path to first name
+$wgOAuth2Client['configuration']['last_name'] = 'last_name'; // JSON path to last name
+```
+
 The **Redirect URI** for your wiki should be:
 
 ```

--- a/SpecialOAuth2Client.php
+++ b/SpecialOAuth2Client.php
@@ -150,10 +150,10 @@ class SpecialOAuth2Client extends SpecialPage {
 			throw new MWException('Could not create user with username:' . $username);
 			die();
 		}
-		if (isset($response['user'][$wgOAuth2Client['configuration']['real_name']) {
-			$real_name = $response['user'][$wgOAuth2Client['configuration']['real_name']);
-		} else if (isset($response['user'][$wgOAuth2Client['configuration']['first_name'] && isset($response['user'][$wgOAuth2Client['configuration']['last_name']) {
-			$real_name = $response['user'][$wgOAuth2Client['configuration']['first_name'] . ' ' . $response['user'][$wgOAuth2Client['configuration']['last_name']);
+		if (isset($wgOAuth2Client['configuration']['real_name'])) {
+			$real_name = $response['user'][$wgOAuth2Client['configuration']['real_name']];
+		} elseif (isset($wgOAuth2Client['configuration']['first_name']) && isset($wgOAuth2Client['configuration']['last_name'])) {
+			$real_name = $response['user'][$wgOAuth2Client['configuration']['first_name']] . ' ' . $response['user'][$wgOAuth2Client['configuration']['last_name']];
 		} else {
 			$real_name = $username;
 		}

--- a/SpecialOAuth2Client.php
+++ b/SpecialOAuth2Client.php
@@ -150,7 +150,14 @@ class SpecialOAuth2Client extends SpecialPage {
 			throw new MWException('Could not create user with username:' . $username);
 			die();
 		}
-		$user->setRealName($username);
+		if (isset($response['user'][$wgOAuth2Client['configuration']['real_name']) {
+			$real_name = $response['user'][$wgOAuth2Client['configuration']['real_name']);
+		} else if (isset($response['user'][$wgOAuth2Client['configuration']['first_name'] && isset($response['user'][$wgOAuth2Client['configuration']['last_name']) {
+			$real_name = $response['user'][$wgOAuth2Client['configuration']['first_name'] . ' ' . $response['user'][$wgOAuth2Client['configuration']['last_name']);
+		} else {
+			$real_name = $username;
+		}
+		$user->setRealName($real_name);
 		$user->setEmail($email);
 		$user->load();
 		if ( !( $user instanceof User && $user->getId() ) ) {


### PR DESCRIPTION
Add optional config options to get user's actual real name instead of just setting `$user->setRealName($username)` if your OAuth2 server gives you full name information.