### PR TITLE
Fix redirect after successful authentication

### DIFF
--- a/SpecialOAuth2Client.php
+++ b/SpecialOAuth2Client.php
@@ -118,7 +118,7 @@ class SpecialOAuth2Client extends SpecialPage {
 			$wgRequest->getSession()->save();
 		}
 
-		if( !$title instanceof Title || 0 > $title->mArticleID ) {
+		if( !$title instanceof Title || 0 > $title->getArticleID() ) {
 			$title = Title::newMainPage();
 		}
 		$wgOut->redirect( $title->getFullURL() );


### PR DESCRIPTION
In current versions of MediaWiki this extension's redirect after successful login is no longer working: Instead of getting redirected to the page where the login flow started, the user is always redirected to the main page.

* fix the check if the wiki title is valid by using the title object's
  getter method instead of directly accessing the member variable.
* closes #8