### PR TITLE
fix redirection after auth is successful

### DIFF
--- a/SpecialOAuth2Client.php
+++ b/SpecialOAuth2Client.php
@@ -128,7 +128,7 @@ class SpecialOAuth2Client extends SpecialPage {
 			$wgRequest->getSession()->save();
 		}
 
-		if( !$title instanceof Title || 0 > $title->mArticleID ) {
+		if( !$title instanceof Title || 0 > $title->getArticleID() ) {
 			$title = Title::newMainPage();
 		}
 		$wgOut->redirect( $title->getFullURL() );


### PR DESCRIPTION
on our wiki (using this oauth extension), users are always redirected to the
main page after auth. i see redirect code already in place, so i think the
intent is to redirect the user back to the page they initially requested.

the Title mArticleID property appears to not be set properly when it is checked
in this code, and as a result our code incorrectly concludes that the redirect
is invalid.

example: in the condition that i changed here, i observed that

  * $title->mArticleID was -1
  * but a call to $title->getArticleID() returned 10

i'm not sure when/how this behavior changed (assuming that mArticleID used to
return a value >= 0 for valid pages), but i did turn up a few possible leads,
primarily https://gerrit.wikimedia.org/r/c/mediawiki/core/+/533271.