### PR TITLE
optionally set user's realname from oauth data

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ composer install
 
 Add the following line to your LocalSettings.php file.
 
-```
+```php
 wfLoadExtension( 'MW-OAuth2Client' );
 ```
 
 Required settings to be added to LocalSettings.php
 
-```
+```php
 $wgOAuth2Client['client']['id']     = ''; // The client ID assigned to you by the provider
 $wgOAuth2Client['client']['secret'] = ''; // The client secret assigned to you by the provider
 
@@ -34,7 +34,6 @@ $wgOAuth2Client['configuration']['redirect_uri']           = ''; // URL for OAut
 
 $wgOAuth2Client['configuration']['username'] = 'username'; // JSON path to username
 $wgOAuth2Client['configuration']['email'] = 'email'; // JSON path to email
-$wgOAuth2Client['configuration']['realname'] = 'realname'; // optional: JSON path to user's real name
 ```
 
 The JSON path should be set to point to the appropriate attributes in the JSON.
@@ -43,7 +42,7 @@ If the properties you want from your JSON object are nested, you can use periods
 
 For example, if user JSON is
 
-```
+```json
 {
     "user": {
         "username": "my username",
@@ -55,7 +54,7 @@ For example, if user JSON is
 
 Then your JSON path configuration should be these
 
-```
+```php
 $wgOAuth2Client['configuration']['username'] = 'user.username'; // JSON path to username
 $wgOAuth2Client['configuration']['email'] = 'user.email'; // JSON path to email
 $wgOAuth2Client['configuration']['realname'] = 'user.full_name'; // JSON path to real name
@@ -71,7 +70,7 @@ http://your.wiki.domain/path/to/wiki/Special:OAuth2Client/callback
 
 Optional further configuration
 
-```
+```php
 $wgOAuth2Client['configuration']['http_bearer_token'] = 'Bearer'; // Token to use in HTTP Authentication
 $wgOAuth2Client['configuration']['query_parameter_token'] = 'auth_token'; // query parameter to use
 $wgOAuth2Client['configuration']['scopes'] = 'read_citizen_info'; //Permissions
@@ -79,13 +78,15 @@ $wgOAuth2Client['configuration']['scopes'] = 'read_citizen_info'; //Permissions
 $wgOAuth2Client['configuration']['service_name'] = 'Citizen Registry'; // the name of your service
 $wgOAuth2Client['configuration']['service_login_link_text'] = 'Login with StarMade'; // the text of the login link
 
+$wgOAuth2Client['configuration']['realname'] = 'realname'; // JSON path to user's real name
+
 ```
 
 Optional Authorization Callback
 
 Provide a callback and error message in the configuration that evaluates a conditional based upon the result of some business logic provided by the authorization endpoint response.
 
-```
+```php
 $wgOAuth2Client['configuration']['authz_callback'] = function($response) {
   if ($response['property']) {
     return true;
@@ -95,8 +96,6 @@ $wgOAuth2Client['configuration']['authz_callback'] = function($response) {
 }; // return true or false based on something from the authorization response
 $wgOAuth2Client['configuration']['authz_failure_message'] // text of error message
 ```
-
-
 
 ### Popup Window
 To use a popup window to login to the external OAuth2 server, copy the JS from modal.js to the [MediaWiki:Common.js](https://www.mediawiki.org/wiki/Manual:Interface/JavaScript) page on your wiki.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ $wgOAuth2Client['configuration']['redirect_uri']           = ''; // URL for OAut
 
 $wgOAuth2Client['configuration']['username'] = 'username'; // JSON path to username
 $wgOAuth2Client['configuration']['email'] = 'email'; // JSON path to email
+$wgOAuth2Client['configuration']['realname'] = 'realname'; // optional: JSON path to user's real name
 ```
 
 The JSON path should be set to point to the appropriate attributes in the JSON.
@@ -46,7 +47,8 @@ For example, if user JSON is
 {
     "user": {
         "username": "my username",
-        "email": "my email"
+        "email": "my email",
+        "full_name": "Grace Hopper"
     }
 }
 ```
@@ -56,6 +58,7 @@ Then your JSON path configuration should be these
 ```
 $wgOAuth2Client['configuration']['username'] = 'user.username'; // JSON path to username
 $wgOAuth2Client['configuration']['email'] = 'user.email'; // JSON path to email
+$wgOAuth2Client['configuration']['realname'] = 'user.full_name'; // JSON path to real name
 ```
 
 You can see [Json Helper Test case](./tests/phpunit/JsonHelperTest.php) for more.

--- a/SpecialOAuth2Client.php
+++ b/SpecialOAuth2Client.php
@@ -180,7 +180,15 @@ class SpecialOAuth2Client extends SpecialPage {
 			throw new MWException('Could not create user with username:' . $username);
 			die();
 		}
-		$user->setRealName($username);
+
+		if ( isset($wgOAuth2Client['configuration']['realname']) ) {
+			$custom_realname = $wgOAuth2Client['configuration']['realname'];
+			$realname = JsonHelper::extractValue($response, $custom_realname);
+			$user->setRealName($realname);
+		} else {
+			$user->setRealName($username);
+		}
+
 		$user->setEmail($email);
 		$user->load();
 		if ( !( $user instanceof User && $user->getId() ) ) {


### PR DESCRIPTION
in the same manner as setting `username` and `email`.

backwards-compatible: if `realname` field is not configured, code continues to use the value in the `username` field as it did before.