### PR TITLE
Allow complicated extract username and email from json

### DIFF
--- a/SpecialOAuth2Client.php
+++ b/SpecialOAuth2Client.php
@@ -174,7 +174,7 @@ class SpecialOAuth2Client extends SpecialPage {
 
 		$username = JsonHelper::extractValue($response, $wgOAuth2Client['configuration']['username']);
 		$email =  JsonHelper::extractValue($response, $wgOAuth2Client['configuration']['email']);
-
+		Hooks::run("OAuth2ClientBeforeUserSave", [&$username, &$email, $response]);
 		$user = User::newFromName($username, 'creatable');
 		if (!$user) {
 			throw new MWException('Could not create user with username:' . $username);


### PR DESCRIPTION
In some case we need to extract data from json in complicated logic.
For this we use hook to let the the developer to user any logic he needs.