### PR TITLE
Fix deprecation with wgUser and isLoggedIn

### DIFF
--- a/OAuth2Client.php
+++ b/OAuth2Client.php
@@ -21,7 +21,7 @@ class OAuth2ClientHooks {
 	public static function onPersonalUrls( array &$personal_urls, Title $title ) {
 
 		global $wgOAuth2Client, $wgUser, $wgRequest;
-		if( $wgUser->isLoggedIn() ) return true;
+		if( $wgUser->isRegistered() ) return true;
 
 
 		# Due to bug 32276, if a user does not have read permissions,

--- a/OAuth2Client.php
+++ b/OAuth2Client.php
@@ -20,8 +20,10 @@ if ( !defined( 'MEDIAWIKI' ) ) {
 class OAuth2ClientHooks {
 	public static function onPersonalUrls( array &$personal_urls, Title $title ) {
 
-		global $wgOAuth2Client, $wgUser, $wgRequest;
-		if( $wgUser->isRegistered() ) return true;
+		global $wgOAuth2Client, $wgRequest;
+
+        $user = RequestContext::getMain()->getUser();
+		if( $user->isRegistered() ) return true;
 
 
 		# Due to bug 32276, if a user does not have read permissions,

--- a/SpecialOAuth2Client.php
+++ b/SpecialOAuth2Client.php
@@ -140,7 +140,7 @@ class SpecialOAuth2Client extends SpecialPage {
 		$service_name = ( isset( $wgOAuth2Client['configuration']['service_name'] ) && 0 < strlen( $wgOAuth2Client['configuration']['service_name'] ) ? $wgOAuth2Client['configuration']['service_name'] : 'OAuth2' );
 
 		$wgOut->setPagetitle( wfMessage( 'oauth2client-login-header', $service_name)->text() );
-		if ( !$wgUser->isLoggedIn() ) {
+		if ( !$wgUser->isRegistered() ) {
 			$wgOut->addWikiMsg( 'oauth2client-you-can-login-to-this-wiki-with-oauth2', $service_name );
 			$wgOut->addWikiMsg( 'oauth2client-login-with-oauth2', $this->getTitle( 'redirect' )->getPrefixedURL(), $service_name );
 

--- a/SpecialOAuth2Client.php
+++ b/SpecialOAuth2Client.php
@@ -136,11 +136,13 @@ class SpecialOAuth2Client extends SpecialPage {
 	}
 
 	private function _default(){
-		global $wgOAuth2Client, $wgOut, $wgUser, $wgScriptPath, $wgExtensionAssetsPath;
+		global $wgOAuth2Client, $wgOut, $wgScriptPath, $wgExtensionAssetsPath;
+
 		$service_name = ( isset( $wgOAuth2Client['configuration']['service_name'] ) && 0 < strlen( $wgOAuth2Client['configuration']['service_name'] ) ? $wgOAuth2Client['configuration']['service_name'] : 'OAuth2' );
 
 		$wgOut->setPagetitle( wfMessage( 'oauth2client-login-header', $service_name)->text() );
-		if ( !$wgUser->isRegistered() ) {
+		$user = RequestContext::getMain()->getUser();
+		if ( !$user->isRegistered() ) {
 			$wgOut->addWikiMsg( 'oauth2client-you-can-login-to-this-wiki-with-oauth2', $service_name );
 			$wgOut->addWikiMsg( 'oauth2client-login-with-oauth2', $this->getTitle( 'redirect' )->getPrefixedURL(), $service_name );
 
@@ -197,8 +199,7 @@ class SpecialOAuth2Client extends SpecialPage {
 		$user->setCookies();
 		$this->getContext()->setUser( $user );
 		$user->saveSettings();
-		global $wgUser;
-		$wgUser = $user;
+		RequestContext::getMain()->setUser( $user );
 		$sessionUser = User::newFromSession($this->getRequest());
 		$sessionUser->load();
 		return $user;


### PR DESCRIPTION
The extension does not work anymore (at least with Mediawiki version 1.38). The cause is the deprecation of `wgUser`. The PR replaces `wgUser` and `isLoggedIn` which is also deprecated and equivalent to `isRegistered`.