### PR TITLE
Add an option to keep users logged in for longer

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ $wgOAuth2Client['configuration']['scopes'] = 'read_citizen_info'; //Permissions
 
 $wgOAuth2Client['configuration']['service_name'] = 'Citizen Registry'; // the name of your service
 $wgOAuth2Client['configuration']['service_login_link_text'] = 'Login with StarMade'; // the text of the login link
+$wgOAuth2Client['configuration']['remember_me'] = true; // Whether to keep user logged in for longer, similarly to what would happen if they checked "Keep me logged in" in password-based login. See https://www.mediawiki.org/wiki/Manual:$wgCookieExpiration . Default: false.
 
 ```
 

--- a/SpecialOAuth2Client.php
+++ b/SpecialOAuth2Client.php
@@ -92,7 +92,7 @@ class SpecialOAuth2Client extends SpecialPage {
 	}
 
 	private function _handleCallback(){
-		global $wgRequest;
+		global $wgRequest, $wgOAuth2Client;
 
 		try {
 			$storedState = $wgRequest->getSession()->get('oauth2state');
@@ -117,7 +117,8 @@ class SpecialOAuth2Client extends SpecialPage {
 
 		$resourceOwner = $this->_provider->getResourceOwner($accessToken);
 		$user = $this->_userHandling( $resourceOwner->toArray() );
-		$user->setCookies();
+		$rememberMe = $wgOAuth2Client['configuration']['remember_me'] ?? false;
+		$user->setCookies(null, null, $rememberMe);
 
 		global $wgOut, $wgRequest;
 		$title = null;


### PR DESCRIPTION
Add new optional config option:
$wgOAuth2Client['configuration']['remember_me']

It controls whether the users should be logged in the way they would if they checked the "Keep me logged in" checkbox in password-based authentication. Basically, the cookies are then set a bit differently, as described in https://www.mediawiki.org/wiki/Manual:$wgCookieExpiration

The default is false, so the behaviour from before this patch is preserved.

This is useful, as without it in, some setups the user will be logged in only for a short period of time, which makes e.g. editing experience pretty annoying.